### PR TITLE
Add woocommerce_after_order_refund_item_name hook

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -43,6 +43,8 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 			<p class="description"><?php echo esc_html( $refund->get_reason() ); ?></p>
 		<?php endif; ?>
 		<input type="hidden" class="order_refund_id" name="order_refund_id[]" value="<?php echo esc_attr( $refund->get_id() ); ?>" />
+
+		<?php do_action( 'woocommerce_after_order_refund_item_name', $refund ); ?>
 	</td>
 
 	<?php do_action( 'woocommerce_admin_order_item_values', null, $refund, $refund->get_id() ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

The added hook `woocommerce_after_order_refund_item_name` will allow developers to display extra information for a refund in the administration area.

For example, if we have a custom functionality of creating a Credit Note document after a refund has been created, we can display the link to the Credit Note below the row with the refund.
